### PR TITLE
Tables instead of bullet point lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,35 @@
 
 The repository contains these folders:
 
-- **fusion360** – source files for [Autodesk Fusion 360](https://www.autodesk.com/products/fusion-360/overview).
-- **fusion360/assemblies** – Combined source files of a maximum of 10 keycaps. These files are used to export the models to STL files. Combining models into one file is a good way to save money on printing as printing services often charge a minimum price per model.
-- **stl** – 3D models for any CAD or Slicer software.
-- **stl/assemblies** – Combined files that you can use in any 3D-printing service like [JLCPCB](https://3d.jlcpcb.com/3d-printing/stereolithography) or [PCBWay](https://www.pcbway.com/rapid-prototyping/3d-printing/). Combining models into one file is a good way to save money on printing as printing services often charge a minimum price per model. If you need other combinations, you can use the source files in the `fusion360/assemblies` folder to create your own STL files.
-- **assets** – folder that contains images and actual photos of keycaps.
+| Folder                   | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **fusion360**            | Source files for [Autodesk Fusion 360](https://www.autodesk.com/products/fusion-360/overview).                                                                                                                                                                                                                                                                                                                                                                        |
+| **fusion360/assemblies** | Combined source files of a maximum of 10 keycaps. These files are used to export the models to STL files. Combining models into one file is a good way to save money on printing as printing services often charge a minimum price per model.                                                                                                                                                                                                                         |
+| **stl**                  | 3D models for any CAD or Slicer software.                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **stl/assemblies**       | Combined files that you can use in any 3D-printing service like [JLCPCB](https://3d.jlcpcb.com/3d-printing/stereolithography) or [PCBWay](https://www.pcbway.com/rapid-prototyping/3d-printing/). Combining models into one file is a good way to save money on printing as printing services often charge a minimum price per model. If you need other combinations, you can use the source files in the `fusion360/assemblies` folder to create your own STL files. |
+| **assets**               | Folder that contains images and actual photos of keycaps.                                                                                                                                                                                                                                                                                                                                                                                                             |
 
 There are currently 19 different keycap models available:
 
-- **Saddle Homing**. A saddle-shaped keycap, similar to the Chicago Steno keycaps, with three little bumps, commonly used for home row index fingers.
-- **Saddle**. A saddle-shaped keycap, similar to the Chicago Steno keycaps.
-- **Dished Homing**. A normal dished keycap with three little bumps, commonly used for home row index fingers.
-- **Dished**. A normal dished keycap.
-- **Tilted 7°**. Same as **Dished**, but top profile has a 7° tilt and the front is lowered.
-- **Tilted 14°**. Same as **Dished**, but top profile has a 14° tilt and the front is lowered.
-- **Tilted 7° Dished**. Same as **Tilted 7°**, but the top profile is dished.
-- **Tilted 14° Dished**. Same as **Tilted 14°**, but the top profile is dished.
-- **Tilted 7° Dished R4**. Same as **Tilted 7° Dished**, but higher profile for the top row.
-- **Tilted 14° Dished R4**. Same as **Tilted 14° Dished**, but higher profile for the top row.
-- **Tilted 7° Slanted 10°**. Same as **Tilted 7°**, but the top profile is slanted 10° to the left/right (two variants).
-- **Tilted 14° Slanted 10°**. Same as **Tilted 14°**, but the top profile is slanted 10° to the left/right (two variants).
-- **Tilted 14° Double Slanted**. Same as **Tilted 14°**, but the top profile is slanted to both sides, intended to go between two tilted keycaps.
-- **Saddle Lower Side**. Same as **Saddle**, but one side is lowered to have a better transition to the **Double Slanted** keycap.
-- **Saddle Lower Side Homing**. Same as **Saddle Homing**, but one side is lowered to have a better transition to the **Double Slanted** keycap.
-- **Thumb**. Same as **Dished**, but with a lowered front side.
-- **Tilted 7° 1.5u**. Same as **Tilted 7°**, but 1.5u size.
+| Model                         | Description                                                                                                                      |
+|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| **Saddle Homing**             | A saddle-shaped keycap, similar to the Chicago Steno keycaps, with three little bumps, commonly used for home row index fingers. |
+| **Saddle**                    | A saddle-shaped keycap, similar to the Chicago Steno keycaps.                                                                    |
+| **Dished Homing**             | A normal dished keycap with three little bumps, commonly used for home row index fingers.                                        |
+| **Dished**                    | A normal dished keycap.                                                                                                          |
+| **Tilted 7°**                 | Same as **Dished**, but top profile has a 7° tilt and the front is lowered.                                                      |
+| **Tilted 14°**                | Same as **Dished**, but top profile has a 14° tilt and the front is lowered.                                                     |
+| **Tilted 7° Dished**          | Same as **Tilted 7°**, but the top profile is dished.                                                                            |
+| **Tilted 14° Dished**         | Same as **Tilted 14°**, but the top profile is dished.                                                                           |
+| **Tilted 7° Dished R4**       | Same as **Tilted 7° Dished**, but higher profile for the top row.                                                                |
+| **Tilted 14° Dished R4**      | Same as **Tilted 14° Dished**, but higher profile for the top row.                                                               |
+| **Tilted 7° Slanted 10°**     | Same as **Tilted 7°**, but the top profile is slanted 10° to the left/right (two variants).                                      |
+| **Tilted 14° Slanted 10°**    | Same as **Tilted 14°**, but the top profile is slanted 10° to the left/right (two variants).                                     |
+| **Tilted 14° Double Slanted** | Same as **Tilted 14°**, but the top profile is slanted to both sides, intended to go between two tilted keycaps.                 |
+| **Saddle Lower Side**         | Same as **Saddle**, but one side is lowered to have a better transition to the **Double Slanted** keycap.                        |
+| **Saddle Lower Side Homing**  | Same as **Saddle Homing**, but one side is lowered to have a better transition to the **Double Slanted** keycap.                 |
+| **Thumb**                     | Same as **Dished**, but with a lowered front side.                                                                               |
+| **Tilted 7° 1.5u**            | Same as **Tilted 7°**, but 1.5u size.                                                                                            |
 
 ## How to print?
 

--- a/README.md
+++ b/README.md
@@ -14,25 +14,26 @@ The repository contains these folders:
 
 There are currently 19 different keycap models available:
 
-| Model                         | Description                                                                                                                      |
-|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| **Saddle Homing**             | A saddle-shaped keycap, similar to the Chicago Steno keycaps, with three little bumps, commonly used for home row index fingers. |
-| **Saddle**                    | A saddle-shaped keycap, similar to the Chicago Steno keycaps.                                                                    |
-| **Dished Homing**             | A normal dished keycap with three little bumps, commonly used for home row index fingers.                                        |
-| **Dished**                    | A normal dished keycap.                                                                                                          |
-| **Tilted 7°**                 | Same as **Dished**, but top profile has a 7° tilt and the front is lowered.                                                      |
-| **Tilted 14°**                | Same as **Dished**, but top profile has a 14° tilt and the front is lowered.                                                     |
-| **Tilted 7° Dished**          | Same as **Tilted 7°**, but the top profile is dished.                                                                            |
-| **Tilted 14° Dished**         | Same as **Tilted 14°**, but the top profile is dished.                                                                           |
-| **Tilted 7° Dished R4**       | Same as **Tilted 7° Dished**, but higher profile for the top row.                                                                |
-| **Tilted 14° Dished R4**      | Same as **Tilted 14° Dished**, but higher profile for the top row.                                                               |
-| **Tilted 7° Slanted 10°**     | Same as **Tilted 7°**, but the top profile is slanted 10° to the left/right (two variants).                                      |
-| **Tilted 14° Slanted 10°**    | Same as **Tilted 14°**, but the top profile is slanted 10° to the left/right (two variants).                                     |
-| **Tilted 14° Double Slanted** | Same as **Tilted 14°**, but the top profile is slanted to both sides, intended to go between two tilted keycaps.                 |
-| **Saddle Lower Side**         | Same as **Saddle**, but one side is lowered to have a better transition to the **Double Slanted** keycap.                        |
-| **Saddle Lower Side Homing**  | Same as **Saddle Homing**, but one side is lowered to have a better transition to the **Double Slanted** keycap.                 |
-| **Thumb**                     | Same as **Dished**, but with a lowered front side.                                                                               |
-| **Tilted 7° 1.5u**            | Same as **Tilted 7°**, but 1.5u size.                                                                                            |
+| Model                         | Description                                                                                                                      | STL                                                         | Fusion 360                                                        |
+|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|-------------------------------------------------------------------|
+| **Saddle Homing**             | A saddle-shaped keycap, similar to the Chicago Steno keycaps, with three little bumps, commonly used for home row index fingers. | <a href="stl/CLP_Saddle_Homing v2.stl">Download</a>         | <a href="fusion360/CLP_Saddle_Homing v2.stl">Download</a>         |
+| **Saddle**                    | A saddle-shaped keycap, similar to the Chicago Steno keycaps.                                                                    | <a href="stl/CLP_Saddle v2.stl">Download</a>                | <a href="fusion360/CLP_Saddle v2.stl">Download</a>                |
+| **Dished Homing**             | A normal dished keycap with three little bumps, commonly used for home row index fingers.                                        | <a href="stl/CLP_Dished_Homing v6.stl">Download</a>         | <a href="fusion360/CLP_Dished_Homing v6.stl">Download</a>         |
+| **Dished**                    | A normal dished keycap.                                                                                                          | <a href="stl/CLP_Dished v3.stl">Download</a>                | <a href="fusion360/CLP_Dished v3.stl">Download</a>                |
+| **Tilted 7°**                 | Same as **Dished**, but top profile has a 7° tilt and the front is lowered.                                                      | <a href="stl/CLP_Tilt7 v8.stl">Download</a>                 | <a href="fusion360/CLP_Tilt7 v8.stl">Download</a>                 |
+| **Tilted 14°**                | Same as **Dished**, but top profile has a 14° tilt and the front is lowered.                                                     | <a href="stl/CLP_Tilt14 v10.stl">Download</a>               | <a href="fusion360/CLP_Tilt14 v10.stl">Download</a>               |
+| **Tilted 7° Dished**          | Same as **Tilted 7°**, but the top profile is dished.                                                                            | <a href="stl/CLP_Dished_Tilt7 v3.stl">Download</a>          | <a href="fusion360/CLP_Dished_Tilt7 v3.stl">Download</a>          |
+| **Tilted 14° Dished**         | Same as **Tilted 14°**, but the top profile is dished.                                                                           | <a href="stl/CLP_Dished_Tilt14 v3.stl">Download</a>         | <a href="fusion360/CLP_Dished_Tilt14 v3.stl">Download</a>         |
+| **Tilted 7° Dished R4**       | Same as **Tilted 7° Dished**, but higher profile for the top row.                                                                | <a href="stl/CLP_Dished_Tilt7_R4 v8.stl">Download</a>       | <a href="fusion360/CLP_Dished_Tilt7_R4 v8.stl">Download</a>       |
+| **Tilted 14° Dished R4**      | Same as **Tilted 14° Dished**, but higher profile for the top row.                                                               | <a href="stl/CLP_Dished_Tilt14_R4 v8.stl">Download</a>      | <a href="fusion360/CLP_Dished_Tilt14_R4 v8.stl">Download</a>      |
+| **Tilted 7° Slanted 10°**     | Same as **Tilted 7°**, but the top profile is slanted 10° to the left/right (two variants).                                      | <a href="stl/CLP_Tilt7_Slant10 v17.stl">Download</a>        | <a href="fusion360/CLP_Tilt7_Slant10 v17.stl">Download</a>        |
+| **Tilted 14° Slanted 10°**    | Same as **Tilted 14°**, but the top profile is slanted 10° to the left/right (two variants).                                     | <a href="stl/CLP_Tilt14_Slant10 v15.stl">Download</a>       | <a href="fusion360/CLP_Tilt14_Slant10 v15.stl">Download</a>       |
+| **Tilted 14° Double Slanted** | Same as **Tilted 14°**, but the top profile is slanted to both sides, intended to go between two tilted keycaps.                 | <a href="stl/CLP_Tilt14_Doubleslant v6.stl">Download</a>    | <a href="fusion360/CLP_Tilt14_Doubleslant v6.stl">Download</a>    |
+| **Saddle Lower Side**         | Same as **Saddle**, but one side is lowered to have a better transition to the **Double Slanted** keycap.                        | <a href="stl/CLP_Saddle_LowSide v5.stl">Download</a>        | <a href="fusion360/CLP_Saddle_LowSide v5.stl">Download</a>        |
+| **Saddle Lower Side Homing**  | Same as **Saddle Homing**, but one side is lowered to have a better transition to the **Double Slanted** keycap.                 | <a href="stl/CLP_Saddle_LowSide_Homing v1.stl">Download</a> | <a href="fusion360/CLP_Saddle_LowSide_Homing v1.stl">Download</a> |
+| **Thumb**                     | Same as **Dished**, but with a lowered front side.                                                                               | <a href="stl/CLP_Thumb v8.stl">Download</a>                 | <a href="fusion360/CLP_Thumb v8.stl">Download</a>                 |
+| **Tilted 7° 1.5u**            | Same as **Tilted 7°**, but 1.5u size.                                                                                            | <a href="stl/CLP_Tilt7_1_5u v13.stl">Download</a>           | <a href="fusion360/CLP_Tilt7_1_5u v13.stl">Download</a>           |
+
 
 ## How to print?
 


### PR DESCRIPTION
I think the README is more readable when elements are formatted in table instead of a bullet point list.

You can see how this looks like here https://github.com/arialdomartini/clp-keycaps